### PR TITLE
update to vmaf 1.3.9, use 4K model and CI, ffmpeg 4.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,25 @@ RUN apt update && \
     apt install -y unzip python python-pip bc autoconf automake build-essential libass-dev libfreetype6-dev \
                    git libsdl2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev \
                    libxcb-xfixes0-dev pkg-config texinfo wget zlib1g-dev libx265-dev=1.9-3 && \
-    pip install --upgrade pandas && \ 
+    pip install --upgrade pandas && \
     apt-get clean autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Install Netflix VMAF
-RUN wget https://github.com/Netflix/vmaf/archive/v1.3.4.tar.gz && \
-    tar -xf v1.3.4.tar.gz && \
-    cd vmaf-1.3.4 && \
+RUN wget https://github.com/Netflix/vmaf/archive/v1.3.9.tar.gz && \
+    tar -xf v1.3.9.tar.gz && \
+    cd vmaf-1.3.9 && \
     cd ptools; make; cd .. && \
     cd wrapper; make; cd .. && \
     make install && \
-    cd ..; rm -rf vmaf-1.3.4/; rm -f v1.3.4.tar.gz
+    cd ..; rm -rf vmaf-1.3.9/; rm -f v1.3.9.tar.gz
 
-# Install ffmpeg
+COPY install_ffmpeg.sh install_ffmpeg.sh
+
+RUN chmod +x ./install_ffmpeg.sh && ./install_ffmpeg.sh
+
 WORKDIR /tools
-
-RUN wget https://service.inet.tu-berlin.de/owncloud/index.php/s/XncfohkrXsxjG7h/download -O ffmpeg.zip && \
-    unzip ffmpeg.zip && \ 
-    rm ffmpeg.zip
-
-ENV PATH="/tools/ffmpeg:${PATH}"
 
 # Add the (relevant) git content
 COPY scripts/ /tools/scripts

--- a/video_encode.sh
+++ b/video_encode.sh
@@ -123,7 +123,7 @@ echo "\"getBitrates\",${SINCE}" >> $TIMINGS
 echo "### Computing quality metrics (prev. took ${SINCE}s) ###"
 
 #compute SSIM, m_ssim, psnr, vmaf
-ffmpeg -nostats -i $TMP/out.m3u8 -i $vid_id -lavfi libvmaf="log_path=quality_metrics.txt:psnr=1:ssim=1:ms_ssim=1" -f null -
+ffmpeg -nostats -i $TMP/out.m3u8 -i $vid_id -lavfi libvmaf="model_path=/usr/local/share/model/vmaf_4k_rb_v0.6.2/vmaf_4k_rb_v0.6.2.pkl:log_path=quality_metrics.txt:psnr=1:ssim=1:ms_ssim=1:enable_conf_interval=1" -f null -
 
 
 SINCE=$(( $(date +%s) - $TS ))


### PR DESCRIPTION
Update with new versions to enable 4K processing, CI calculation.

Freezes ffmpeg to 4.0.2.

Could still be improved by freezing x264, x265, and libvpx.